### PR TITLE
sortable directive type

### DIFF
--- a/src/create-sortable.ts
+++ b/src/create-sortable.ts
@@ -15,6 +15,15 @@ interface Sortable {
   get isActiveDroppable(): boolean;
 }
 
+declare module "solid-js" {
+  namespace JSX {
+    interface Directives {
+      sortable: Sortable;
+    }
+  }
+}
+
+
 const createSortable = (
   id: string | number,
   data: Record<string, any> = {}

--- a/src/create-sortable.ts
+++ b/src/create-sortable.ts
@@ -23,7 +23,6 @@ declare module "solid-js" {
   }
 }
 
-
 const createSortable = (
   id: string | number,
   data: Record<string, any> = {}

--- a/src/create-sortable.ts
+++ b/src/create-sortable.ts
@@ -18,7 +18,7 @@ interface Sortable {
 declare module "solid-js" {
   namespace JSX {
     interface Directives {
-      [key: string]: Sortable | boolean;
+      sortable: boolean;
     }
   }
 }
@@ -114,7 +114,7 @@ const createSortable = (
     }
   ) as unknown as Sortable;
 
-  return sortable;
+  return { sortable };
 };
 
 export { createSortable };

--- a/src/create-sortable.ts
+++ b/src/create-sortable.ts
@@ -18,7 +18,7 @@ interface Sortable {
 declare module "solid-js" {
   namespace JSX {
     interface Directives {
-      sortable: Sortable;
+      [key: string]: Sortable | boolean;
     }
   }
 }


### PR DESCRIPTION
Sortable directive is not added to the JSX directive typing, leading to a typescript error

example: https://stackblitz.com/edit/solid-vite-rtvzss?file=src%2Findex.tsx