### PR TITLE
Fix a couple of bugs related to using solid-dnd with nested draggables & droppables

### DIFF
--- a/src/drag-drop-context.tsx
+++ b/src/drag-drop-context.tsx
@@ -11,6 +11,7 @@ import {
   Component,
   createContext,
   createEffect,
+  createMemo,
   mergeProps,
   PropsWithChildren,
   untrack,
@@ -227,18 +228,19 @@ const DragDropProvider: Component<DragDropContextProps> = (passedProps) => {
       }
     });
   };
-  const activeDraggable = (): Draggable | null => {
+
+  const activeDraggable = createMemo((): Draggable | null => {
     if (state.active.draggable) {
       return state.draggables[state.active.draggable] || null;
     }
     return null;
-  };
-  const previousDraggable = (): Draggable | null => {
+  });
+  const previousDraggable = createMemo((): Draggable | null => {
     if (state.previous.draggable) {
       return state.draggables[state.previous.draggable] || null;
     }
     return null;
-  };
+  });
   const anyDraggableActive = (): boolean => state.active.draggable !== null;
   const addDroppable = ({
     id,
@@ -293,18 +295,18 @@ const DragDropProvider: Component<DragDropContextProps> = (passedProps) => {
       }
     });
   };
-  const activeDroppable = (): Droppable | null => {
+  const activeDroppable = createMemo((): Droppable | null => {
     if (state.active.droppable) {
       return state.droppables[state.active.droppable] || null;
     }
     return null;
-  };
-  const previousDroppable = (): Droppable | null => {
+  });
+  const previousDroppable = createMemo((): Droppable | null => {
     if (state.previous.droppable) {
       return state.droppables[state.previous.droppable] || null;
     }
     return null;
-  };
+  });
   const anyDroppableActive = (): boolean => state.active.droppable !== null;
   const addSensor = ({ id, activators }: Sensor): void => {
     setState("sensors", id, { id, activators });

--- a/src/drag-drop-context.tsx
+++ b/src/drag-drop-context.tsx
@@ -177,7 +177,7 @@ const DragDropProvider: Component<DragDropContextProps> = (passedProps) => {
         set transformed(_) {},
         _pendingCleanup: false,
       });
-      if (existingDraggable) {
+      if (existingDraggable && state.active.draggable === id) {
         const layoutDelta = {
           x: existingDraggable.layout.x - layout.x,
           y: existingDraggable.layout.y - layout.y,

--- a/src/drag-drop-context.tsx
+++ b/src/drag-drop-context.tsx
@@ -52,10 +52,10 @@ interface Sensor {
   activators: { [K in keyof HTMLElementEventMap]?: SensorActivator<K> };
 }
 
-type Transformer = (
+type Transformer = ((
   transform: Transform,
   context: { type: "draggables" | "droppables"; id: string | number }
-) => Transform;
+) => Transform) & { draggableId: string | number };
 
 interface DragDropState {
   draggables: Record<string | number, Draggable>;


### PR DESCRIPTION
I tried to fix a few problems I came across trying to use this library with nested draggables & droppables. 

### Skip adding transformer when not in active drag

By the commit message of https://github.com/thisbeyond/solid-dnd/commit/94d6053296c5cb8a9ec906a7f6011f35d2c8c659 the Transformer is used to correct the displacement during an active drag. But, it appears to also apply when recreating a draggable after a drop. I added a check to only apply the transformer if the recreated draggable is involved in an active drag. 

Without this change, the draggable sometimes has a residual transform applied after dropping it in another container.

### Prevent drag handlers from firing when dependencies update without changing

Using the accessors activeDraggable, previousDraggable, activeDroppable and previousDroppable in an effect can cause the effect to trigger whenever their dependencies update. These dependencies sometimes update without affecting the value of these signals, leading to spurious effect triggers. This sometimes causes some drag events to fire multiple times.

By memoizing these accessors we can prevent them from triggering the effect, and thereby triggering the drag events to fire again

### Fix type errors on Transformer

Typescript complained about the use of draggableId on Transformer. Adding it to the type definition shuts it up.
