### PR TITLE
Update type definitions for components using children prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,11 @@
         "release-it": "^15.0.0",
         "rollup": "^2.71.1",
         "rollup-preset-solid": "^1.4.0",
-        "solid-js": "^1.1.0",
+        "solid-js": "^1.4.3",
         "typescript": "^4.6.4"
       },
       "peerDependencies": {
-        "solid-js": "^1.1.0"
+        "solid-js": "^1.4.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6687,9 +6687,9 @@
       }
     },
     "node_modules/solid-js": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.2.6.tgz",
-      "integrity": "sha512-NvPHJ5Vj5f+ZJWIioickrC55seovSkDtm5NzSpnoUk3z4tATv0STpy5iuGNEn51ZORUcwpZzrMAtOCGziXU1XA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.4.3.tgz",
+      "integrity": "sha512-3uh2cbT4ICronIasLAxycF6SVgvqcfwFCDCzlEA9CEahn1qQg8Rw8aRGiI4O51PrHcN5aPRO9knYYRCs0PgzcQ==",
       "dev": true
     },
     "node_modules/source-map-support": {
@@ -12338,9 +12338,9 @@
       }
     },
     "solid-js": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.2.6.tgz",
-      "integrity": "sha512-NvPHJ5Vj5f+ZJWIioickrC55seovSkDtm5NzSpnoUk3z4tATv0STpy5iuGNEn51ZORUcwpZzrMAtOCGziXU1XA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.4.3.tgz",
+      "integrity": "sha512-3uh2cbT4ICronIasLAxycF6SVgvqcfwFCDCzlEA9CEahn1qQg8Rw8aRGiI4O51PrHcN5aPRO9knYYRCs0PgzcQ==",
       "dev": true
     },
     "source-map-support": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "git+https://github.com/thisbeyond/solid-dnd.git"
   },
   "peerDependencies": {
-    "solid-js": "^1.1.0"
+    "solid-js": "^1.4.3"
   },
   "devDependencies": {
     "@release-it/keep-a-changelog": "^3.0.0",
@@ -46,7 +46,7 @@
     "release-it": "^15.0.0",
     "rollup": "^2.71.1",
     "rollup-preset-solid": "^1.4.0",
-    "solid-js": "^1.1.0",
+    "solid-js": "^1.4.3",
     "typescript": "^4.6.4"
   },
   "publishConfig": {

--- a/src/drag-drop-context.tsx
+++ b/src/drag-drop-context.tsx
@@ -8,11 +8,11 @@ import {
 } from "./layout";
 import {
   batch,
-  Component,
   createContext,
   createEffect,
   mergeProps,
-  PropsWithChildren,
+  ParentComponent,
+  ParentProps,
   untrack,
   useContext,
 } from "solid-js";
@@ -129,10 +129,14 @@ type DragEventHandler = (event: DragEvent) => void;
 
 const Context = createContext<DragDropContext>();
 
-const DragDropProvider: Component<DragDropContextProps> = (passedProps) => {
+const DragDropProvider: ParentComponent<DragDropContextProps> = (
+  passedProps
+) => {
   const props: Pick<Required<DragDropContextProps>, "collisionDetector"> &
-    Omit<PropsWithChildren<DragDropContextProps>, "collisionDetector"> =
-    mergeProps({ collisionDetector: mostIntersecting }, passedProps);
+    Omit<ParentProps<DragDropContextProps>, "collisionDetector"> = mergeProps(
+    { collisionDetector: mostIntersecting },
+    passedProps
+  );
   const [state, setState] = createStore<DragDropState>({
     draggables: {},
     droppables: {},

--- a/src/drag-drop-sensors.tsx
+++ b/src/drag-drop-sensors.tsx
@@ -1,7 +1,7 @@
-import { Component } from "solid-js";
+import { ParentComponent } from "solid-js";
 import { createPointerSensor } from "./create-pointer-sensor";
 
-const DragDropSensors: Component = (props) => {
+const DragDropSensors: ParentComponent = (props) => {
   createPointerSensor();
   return <>{props.children}</>;
 };

--- a/src/drag-overlay.tsx
+++ b/src/drag-overlay.tsx
@@ -1,14 +1,14 @@
 import { useDragDropContext } from "./drag-drop-context";
 import { layoutStyle, transformStyle } from "./style";
 import { Portal } from "solid-js/web";
-import { Component, JSX, Show } from "solid-js";
+import { JSX, ParentComponent, Show } from "solid-js";
 
 interface DragOverlayProps {
   class?: string;
   style?: JSX.CSSProperties;
 }
 
-const DragOverlay: Component<DragOverlayProps> = (props) => {
+const DragOverlay: ParentComponent<DragOverlayProps> = (props) => {
   const [, { anyDraggableActive, activeDraggable, setUsingDragOverlay }] =
     useDragDropContext()!;
 

--- a/src/sortable-context.tsx
+++ b/src/sortable-context.tsx
@@ -1,9 +1,9 @@
 import { useDragDropContext } from "./drag-drop-context";
 import { moveArrayItem } from "./move-array-item";
 import {
-  Component,
   createContext,
   createEffect,
+  ParentComponent,
   untrack,
   useContext,
 } from "solid-js";
@@ -20,7 +20,7 @@ interface SortableContextProps {
 type SortableContext = [Store<SortableContextState>, {}];
 
 const Context = createContext<SortableContext>();
-const SortableProvider: Component<SortableContextProps> = (props) => {
+const SortableProvider: ParentComponent<SortableContextProps> = (props) => {
   const [dndState] = useDragDropContext()!;
 
   const [state, setState] = createStore<SortableContextState>({


### PR DESCRIPTION
This PR bumps the version of `solid-js` to `v1.4.3` and updates
type definitions of Components using children prop to use, 
`ParentComponent` and `ParentProps`.
Resolves #39 