### PR TITLE
Support JSX.Element in DragOverlay children

### DIFF
--- a/src/drag-overlay.tsx
+++ b/src/drag-overlay.tsx
@@ -6,7 +6,7 @@ import { transformStyle } from "./style";
 import { elementLayout } from "./layout";
 
 interface DragOverlayProps {
-  children: Element | ((activeDraggable: Draggable | null) => Element);
+  children: JSX.Element | Element | ((activeDraggable: Draggable | null) => (JSX.Element | Element));
   class?: string;
   style?: JSX.CSSProperties;
 }

--- a/src/drag-overlay.tsx
+++ b/src/drag-overlay.tsx
@@ -6,7 +6,7 @@ import { transformStyle } from "./style";
 import { elementLayout } from "./layout";
 
 interface DragOverlayProps {
-  children: JSX.Element | Element | ((activeDraggable: Draggable | null) => (JSX.Element | Element));
+  children: JSX.Element | ((activeDraggable: Draggable | null) => JSX.Element);
   class?: string;
   style?: JSX.CSSProperties;
 }


### PR DESCRIPTION
When using the `DragOverlay` component from TypeScript, it is an error to have `JSX.Element` children. This seems to be a major limitation, as this is the type of children we get when writing in `.tsx` files with Solid.

For instance, if we take a snippet from "Sortable list (horizontal)" example and try using it in a `.tsx` file we get an error.
```
      <DragOverlay>
        <div class="sortable">{activeItem()}</div>
      </DragOverlay>
```

Resulting error:
```
Type 'Element' is not assignable to type '(Element | ((activeDraggable: Draggable | null) => Element)) & Element'.
  Type 'undefined' is not assignable to type '(Element | ((activeDraggable: Draggable | null) => Element)) & Element'.ts(2322)
drag-overlay.d.ts(4, 5): The expected type comes from property 'children' which is declared here on type 'IntrinsicAttributes & DragOverlayProps & { children?: Element; }'
```

This PR fixes the problem by allowing `JSX.Element` children for the `DragOverlay`.
