### PR TITLE
Fixed the children prop for DragOverlay

### DIFF
--- a/src/drag-overlay.tsx
+++ b/src/drag-overlay.tsx
@@ -11,7 +11,7 @@ interface DragOverlayProps {
   style?: JSX.CSSProperties;
 }
 
-const DragOverlay: ParentComponent<DragOverlayProps> = (props) => {
+const DragOverlay = (props: DragOverlayProps) => {
   const [state, { onDragStart, onDragEnd, setOverlay, clearOverlay }] =
     useDragDropContext()!;
 


### PR DESCRIPTION
`DragOverlay` is currently defined as `ParentComponent<DragOverlayProps>`, but it doesn't work in the following scenario in a `.tsx` file:

```
<DragOverlay>
  {(draggable) => <div>Drag overlay for {draggable?.id}</div>}
</DragOverlay>
```

It will throw the following error

```
Type '(draggable: Draggable$1 | null) => Element' is not assignable to type '((number | boolean | Node | ArrayElement | (string & {}) | ((activeDraggable: Draggable$1 | null) => Element)) & (number | boolean | Node | ArrayElement | (string & {}))) | null | undefined'.
  Type '(draggable: Draggable$1 | null) => Element' is not assignable to type '((activeDraggable: Draggable$1 | null) => Element) & number'.
    Type '(draggable: Draggable$1 | null) => Element' is not assignable to type 'number'.
```

The reason for that is because `ParentComponent` overrides `children`, so the definition in `DragOverlayProps` is ignored.