### PR TITLE
Memoise a bunch of stuff

### DIFF
--- a/src/create-draggable.ts
+++ b/src/create-draggable.ts
@@ -44,9 +44,9 @@ const createDraggable = (id: Id, data: Record<string, any> = {}): Draggable => {
   onCleanup(() => removeDraggable(id));
 
   const isActiveDraggable = createMemo(() => state.active.draggableId === id);
-  const transform = () => {
+  const transform = createMemo(() => {
     return state.draggables[id]?.transform || noopTransform();
-  };
+  });
 
   const draggable = Object.defineProperties(
     (element: HTMLElement, accessor?: () => { skipTransform?: boolean }) => {
@@ -97,9 +97,7 @@ const createDraggable = (id: Id, data: Record<string, any> = {}): Draggable => {
       },
       dragActivators: {
         enumerable: true,
-        get: () => {
-          return draggableActivators(id, true);
-        },
+        get: createMemo(() => draggableActivators(id, true)),
       },
       transform: {
         enumerable: true,

--- a/src/create-draggable.ts
+++ b/src/create-draggable.ts
@@ -1,6 +1,7 @@
 import {
   createEffect,
   createSignal,
+  createMemo,
   onCleanup,
   onMount,
   Setter,
@@ -42,7 +43,7 @@ const createDraggable = (id: Id, data: Record<string, any> = {}): Draggable => {
   });
   onCleanup(() => removeDraggable(id));
 
-  const isActiveDraggable = () => state.active.draggableId === id;
+  const isActiveDraggable = createMemo(() => state.active.draggableId === id);
   const transform = () => {
     return state.draggables[id]?.transform || noopTransform();
   };

--- a/src/create-droppable.ts
+++ b/src/create-droppable.ts
@@ -1,5 +1,6 @@
 import {
   createEffect,
+  createMemo,
   createSignal,
   onCleanup,
   onMount,
@@ -40,10 +41,10 @@ const createDroppable = (id: Id, data: Record<string, any> = {}): Droppable => {
   });
   onCleanup(() => removeDroppable(id));
 
-  const isActiveDroppable = () => state.active.droppableId === id;
-  const transform = () => {
+  const isActiveDroppable = createMemo(() => state.active.droppableId === id);
+  const transform = createMemo(() => {
     return state.droppables[id]?.transform || noopTransform();
-  };
+  });
   const droppable = Object.defineProperties(
     (element: HTMLElement, accessor?: () => { skipTransform?: boolean }) => {
       const config = accessor ? accessor() : {};

--- a/src/create-pointer-sensor.ts
+++ b/src/create-pointer-sensor.ts
@@ -1,4 +1,4 @@
-import { onCleanup, onMount } from "solid-js";
+import { createMemo, onCleanup, onMount } from "solid-js";
 
 import {
   Coordinates,
@@ -32,7 +32,7 @@ const createPointerSensor = (id: Id = "pointer-sensor"): void => {
     removeSensor(id);
   });
 
-  const isActiveSensor = () => state.active.sensorId === id;
+  const isActiveSensor = createMemo(() => state.active.sensorId === id);
 
   const initialCoordinates: Coordinates = { x: 0, y: 0 };
 

--- a/src/create-sortable.ts
+++ b/src/create-sortable.ts
@@ -1,4 +1,4 @@
-import { createEffect, onCleanup, onMount } from "solid-js";
+import { createEffect, createMemo, onCleanup, onMount } from "solid-js";
 
 import { createDraggable } from "./create-draggable";
 import { createDroppable } from "./create-droppable";
@@ -30,12 +30,16 @@ const createSortable = (id: Id, data: Record<string, any> = {}): Sortable => {
   const droppable = createDroppable(id, data);
   const setNode = combineRefs(draggable.ref, droppable.ref);
 
-  const initialIndex = (): number => sortableState.initialIds.indexOf(id);
-  const currentIndex = (): number => sortableState.sortedIds.indexOf(id);
+  const initialIndex = createMemo((): number =>
+    sortableState.initialIds.indexOf(id)
+  );
+  const currentIndex = createMemo((): number =>
+    sortableState.sortedIds.indexOf(id)
+  );
   const layoutById = (id: Id): Layout | null =>
     dndState.droppables[id]?.layout || null;
 
-  const sortedTransform = (): Transform => {
+  const sortedTransform = createMemo((): Transform => {
     const delta = noopTransform();
     const resolvedInitialIndex = initialIndex();
     const resolvedCurrentIndex = currentIndex();
@@ -53,7 +57,7 @@ const createSortable = (id: Id, data: Record<string, any> = {}): Sortable => {
     }
 
     return delta;
-  };
+  });
 
   const transformer: Transformer = {
     id: "sortableOffset",
@@ -67,13 +71,13 @@ const createSortable = (id: Id, data: Record<string, any> = {}): Sortable => {
   onMount(() => addTransformer("droppables", id, transformer));
   onCleanup(() => removeTransformer("droppables", id, transformer.id));
 
-  const transform = (): Transform => {
+  const transform = createMemo((): Transform => {
     return (
       (id === dndState.active.draggableId && !dndState.active.overlay
         ? dndState.draggables[id]?.transform
         : dndState.droppables[id]?.transform) || noopTransform()
     );
-  };
+  });
 
   const sortable = Object.defineProperties(
     (element: HTMLElement) => {

--- a/src/drag-overlay.tsx
+++ b/src/drag-overlay.tsx
@@ -1,5 +1,5 @@
 import { Portal } from "solid-js/web";
-import { Component, JSX, Show } from "solid-js";
+import { Component, JSX, Show, createMemo } from "solid-js";
 
 import { Draggable, useDragDropContext } from "./drag-drop-context";
 import { transformStyle } from "./style";
@@ -39,7 +39,7 @@ const DragOverlay: Component<DragOverlayProps> = (props) => {
 
   onDragEnd(() => queueMicrotask(clearOverlay));
 
-  const style = (): JSX.CSSProperties => {
+  const style = createMemo((): JSX.CSSProperties => {
     const overlay = state.active.overlay;
     const draggable = state.active.draggable;
     if (!overlay || !draggable) return {};
@@ -54,7 +54,7 @@ const DragOverlay: Component<DragOverlayProps> = (props) => {
       ...transformStyle(overlay.transform),
       ...props.style,
     };
-  };
+  });
 
   return (
     <Portal mount={document.body}>
@@ -70,4 +70,3 @@ const DragOverlay: Component<DragOverlayProps> = (props) => {
 };
 
 export { DragOverlay };
-


### PR DESCRIPTION
This PR fixes overly eager execution of effects in components

> [!WARNING]
> I have not yet finished tested this in my project

```tsx
import { Show, type Component, createEffect } from 'solid-js';
import { createDraggable } from '@thisbeyond/solid-dnd';

export interface CardProps {
  title: string;
  details?: string;
}

const Card: Component<CardProps> = (p) => {
  const drag = createDraggable(p.title);
  // This effect will run even when a different draggable is dragged
  createEffect(() => console.log('Drag State Updated:', drag.isActiveDraggable, id));
  return (
    <article
      use:drag
      k-card={p.title}
      drag-id={id}
      class="rounded-2 border py-2 px-3 dark:(bg-slate-800 border-coolgray) light:(bg-sky-200 border-stone-900) min-h-20"
      classList={{ '-rot-4': drag.isActiveDraggable }}
    >
      <h3 class="text-xl font-bold pb-2">{p.title}</h3>
       <p>{p.details}</p>
    </article>
  );
};

export default Card
```
## Updates:

- Nothing to update ❎
- Updated everything ✅
- Unchecked ❓


| File                       | Change |
| -------------------------- | ------ |
| `colision.ts`              | ❎     |
| `combine-refs.ts`          | ❎     |
| `create-dragable.ts`       | ✔      |
| `create-dropable.ts`       | ✔      |
| `create-pointer-sensor.ts` | ✔      |
| `create-sortable.ts`       | ✔      |
| `drag-drop-context.tsx`    | ❓     |
| `drag-drop-debugger.tsx`   | ❎     |
| `drag-drop-sensors.tsx`    | ❎     |
| `drag-overlay.tsx`         | ✔      |
| `index.tsx`                | ❎     |
| `layout.ts`                | ❎     |
| `move-array-item.ts`       | ❎     |
| `sortable-context.tsx`     | ❎     |
| `style.ts`                 | ❎     |
