### PR TITLE
Try to support sortables of different sizes.

### DIFF
--- a/src/create-sortable.ts
+++ b/src/create-sortable.ts
@@ -13,7 +13,7 @@ import {
 import { Layout, noopTransform, Transform, transformsAreEqual } from "./layout";
 import { transformStyle } from "./style";
 
-interface Sortable {
+export interface Sortable {
   (element: HTMLElement): void;
   ref: RefSetter<HTMLElement | null>;
   get transform(): Transform;
@@ -47,8 +47,19 @@ const createSortable = (id: Id, data: Record<string, any> = {}): Sortable => {
       );
 
       if (currentLayout && targetLayout) {
-        delta.x = targetLayout.x - currentLayout.x;
-        delta.y = targetLayout.y - currentLayout.y;
+        const movingDownOrRight = resolvedInitialIndex < resolvedCurrentIndex;
+
+        delta.x = movingDownOrRight
+          ? targetLayout.width +
+            // horizontal gap
+            (targetLayout.x - (currentLayout.x + currentLayout.width))
+          : targetLayout.x - currentLayout.x;
+
+        delta.y = movingDownOrRight
+          ? targetLayout.height +
+            // vertical gap
+            (targetLayout.y - (currentLayout.y + currentLayout.height))
+          : targetLayout.y - currentLayout.y;
       }
     }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,3 +18,4 @@ export type {
   Transformer,
 } from "./drag-drop-context";
 export type { CollisionDetector } from "./collision";
+export type { Sortable } from "./create-sortable";


### PR DESCRIPTION
Hello. I was able to correctly reposition adjacent `Sortable`s of different sizes. But problem arouse when I tried to drag an item further than the adjacent droppable. The problem, I think, relates to the #9 issue. Here is an example.
Let's say we have a horizontal list of 3 elements. We try to move the first one over the second element.
```
|____| |__| |__|
   1     2    3
```
They are swapped correctly.
```
|__| |____| |__|
  2     1     3
```
But if we continue moving towards third element, we see that there is a big gap between moved second and moved third element.

> Third element may overlap with the second one if we are moving smaller element towards bigger ones.

That's because third element positions itself according to the layout of the second element of the original list, not the changed layout of the current second element.
```
|__|   |_|_|___|
  2      3   1
```
Surprisingly, the first element positions correctly, but becomes overlapped with the third element. I couldn't solve this problem. I am probably missing something or my understanding of the issue reason is not correct. @martinpengellyphillips I think I need your help with this, at least to verify that my guess is correct.