### PR TITLE
fix: properly shuffle around sortables when draghandle is separate div

### DIFF
--- a/src/create-sortable.ts
+++ b/src/create-sortable.ts
@@ -75,25 +75,31 @@ const createSortable = (id: Id, data: Record<string, any> = {}): Sortable => {
     );
   };
 
+  const linkTransformUpdates = (element: HTMLElement) => {
+    createEffect(() => {
+      const resolvedTransform = transform();
+      if (!transformsAreEqual(resolvedTransform, noopTransform())) {
+        const style = transformStyle(transform());
+        element.style.setProperty("transform", style.transform ?? null);
+      } else {
+        element.style.removeProperty("transform");
+      }
+    });
+  };
+
   const sortable = Object.defineProperties(
     (element: HTMLElement) => {
       draggable(element, () => ({ skipTransform: true }));
       droppable(element, () => ({ skipTransform: true }));
-
-      createEffect(() => {
-        const resolvedTransform = transform();
-        if (!transformsAreEqual(resolvedTransform, noopTransform())) {
-          const style = transformStyle(transform());
-          element.style.setProperty("transform", style.transform ?? null);
-        } else {
-          element.style.removeProperty("transform");
-        }
-      });
+      linkTransformUpdates(element);
     },
     {
       ref: {
         enumerable: true,
-        value: setNode,
+        value: (element: HTMLElement) => {
+          setNode(element);
+          linkTransformUpdates(element);
+        },
       },
       transform: {
         enumerable: true,


### PR DESCRIPTION
Hi, thanks for all your work on this awesome library!

I tried implementing the separate drag handler with sortable as described in #84, but I noticed that the sortables weren't shuffling around as I dragged it around anymore. I think I narrowed down the problem, with a fix that I've included in this PR.

Before: 
![ezgif-7-21591bd13f](https://github.com/thisbeyond/solid-dnd/assets/13251689/da99cb0b-35ed-4762-b2cb-d7605fbcf0da)

After:
![ezgif-7-d7cc2cf7d2](https://github.com/thisbeyond/solid-dnd/assets/13251689/6e6655e3-b92e-44e0-bb4a-2e075ce900b4)

Let me know if there's anything you'd like to change about the implementation, or feel free to edit it yourself. I'm not the most attentive to github notifications, but I'll try my best to respond 😅 