### PR TITLE
fix transforming sortable items

### DIFF
--- a/src/create-sortable.ts
+++ b/src/create-sortable.ts
@@ -42,13 +42,19 @@ const createSortable = (id: Id, data: Record<string, any> = {}): Sortable => {
 
     if (resolvedCurrentIndex !== resolvedInitialIndex) {
       const currentLayout = layoutById(id);
-      const targetLayout = layoutById(
-        sortableState.initialIds[resolvedCurrentIndex]
-      );
+      const draggableLayout = layoutById(dndState.active.draggableId!);
 
-      if (currentLayout && targetLayout) {
-        delta.x = targetLayout.x - currentLayout.x;
-        delta.y = targetLayout.y - currentLayout.y;
+      if (currentLayout && draggableLayout) {
+        if (currentLayout.x !== draggableLayout.x) {
+          delta.x = draggableLayout.width;
+        }
+        if (currentLayout.y !== draggableLayout.y) {
+          delta.y = draggableLayout.height;
+        }
+        if (resolvedCurrentIndex < resolvedInitialIndex) {
+          delta.x *= -1;
+          delta.y *= -1;
+        }
       }
     }
 


### PR DESCRIPTION
I experienced an issue where sortable items with different heights were not transformed properly
The issue was that the delta was calculated as target.x - current.x (or target.y - current.y)
the delta was the diff between an item and the one before/after them, instead of the size of the dragged item
Changed it to transform based on the size of the dragged item

here is a reproduction repo https://stackblitz.com/edit/solidjs-templates-atuhev