### PR TITLE
Export `Layout` class and `elementLayout` function from `index.ts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Export `Layout` class and `elementLayout` function for external use
+
 ## [0.7.5] - 2023-11-17
 
 ### Fixed

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ export { createSortable } from "./create-sortable";
 export { layoutStyle, transformStyle, maybeTransformStyle } from "./style";
 export { closestCenter, closestCorners, mostIntersecting } from "./collision";
 export { DragDropDebugger } from "./drag-drop-debugger";
+export { Layout, elementLayout } from "./layout";
 export type {
   Id,
   DragEventHandler,


### PR DESCRIPTION
Closes #122

I've declared this as "Fixed" in the changelog, but one might also argue that it should be "Added". I'm leaving that decision up to you @martinpengellyphillips :slightly_smiling_face: